### PR TITLE
fix: `--stat`'s path argument is not optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Arguments:
 Options:
   -v, --verbose            Display verbose log
   --config <path>          Path to suppressConfig
-  --stat [path]            Display suppress stat
+  --stat <path>            Display suppress stat
   --strict-scope           Error scopeId would be as deep as possible
   --changed                Only check changed files compared with target_branch
   --create-default         Create a .ts-bulk-suppressions.json file

--- a/src/index.ts
+++ b/src/index.ts
@@ -140,7 +140,7 @@ function main(options: ProgramOptions): void {
 program
   .option('-v, --verbose', 'Display verbose log')
   .option('--config <path>', 'Path to suppressConfig')
-  .option('--stat [path]', 'Display suppress stat')
+  .option('--stat <path>', 'Display suppress stat')
   .option('--strict-scope', 'Error scopeId would be as deep as possible')
   .option('--changed', 'Only check changed files compared with target_branch')
   .option('--create-default', 'Create a .ts-bulk-suppressions.json file')


### PR DESCRIPTION
If `--stat` is invoked without the `path` argument, then `mergedConfig.stat` becomes a boolean, and causes the program to crash here:

https://github.com/tiktok/ts-bulk-suppress/blob/fddfb1855b07a10dee59c694780522cf55fb08da/src/index.ts#L136-L138