### PR TITLE
add hashbang to the executable ./bin file

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -1,1 +1,2 @@
+#!/usr/bin/env node
 require('../dist/index');


### PR DESCRIPTION
While working on #9 I realised the CLI entrypoint is missing `#!/usr/bin/env node`, which makes local development a bit cumbersome.

According to the npm docs[^1]:

> Please make sure that your file(s) referenced in `bin` starts with `#!/usr/bin/env node`, otherwise the scripts are started without the node executable!

[^1]: https://docs.npmjs.com/cli/v11/configuring-npm/package-json#bin
