### PR TITLE
Sort suppressors for deterministic output

### DIFF
--- a/src/tsc-bulk.ts
+++ b/src/tsc-bulk.ts
@@ -346,7 +346,9 @@ export function deduplicateSuppressors(suppressors: BulkSuppressor[]): BulkSuppr
     return false;
   });
 
-  return uniqueSuppressors;
+  return uniqueSuppressors.sort(
+    (a, b) => a.filename.localeCompare(b.filename) || a.scopeId.localeCompare(b.scopeId) || a.code - b.code
+  );
 }
 
 export function getBulkConfig(options: ProgramOptions): {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,6 +1,8 @@
 import path from 'path';
 import { execSync } from 'child_process';
-import { rmSync, existsSync } from 'fs-extra';
+import { readFileSync, rmSync, existsSync } from 'fs-extra';
+import { deduplicateSuppressors } from '../src/tsc-bulk';
+import type { BulkSuppressor } from '../src/types';
 
 describe('App pass test', () => {
   const toolScriptPath = path.resolve(__dirname, '../dist/index.js');
@@ -28,5 +30,67 @@ describe('App pass test', () => {
   it(`pass because filtered ignoreExternalError`, () => {
     expect(() => execSync(`node ${toolScriptPath} --ignore-external-error`, { cwd: appDir })).not.toThrow();
     if (existsSync(bulkConfigPath)) rmSync(bulkConfigPath);
+  });
+});
+
+describe('deduplicateSuppressors', () => {
+  it('removes duplicate suppressors', () => {
+    const input: BulkSuppressor[] = [
+      { filename: 'a.ts', scopeId: 'fn1', code: 1001 },
+      { filename: 'a.ts', scopeId: 'fn1', code: 1001 },
+      { filename: 'b.ts', scopeId: 'fn2', code: 1002 }
+    ];
+    const result = deduplicateSuppressors(input);
+    expect(result).toHaveLength(2);
+  });
+
+  it('sorts output by filename, then scopeId, then code', () => {
+    const input: BulkSuppressor[] = [
+      { filename: 'c.ts', scopeId: 'fn1', code: 1001 },
+      { filename: 'a.ts', scopeId: 'fn2', code: 1002 },
+      { filename: 'a.ts', scopeId: 'fn1', code: 1003 },
+      { filename: 'b.ts', scopeId: 'fn1', code: 1001 },
+      { filename: 'a.ts', scopeId: 'fn1', code: 1001 }
+    ];
+    const result = deduplicateSuppressors(input);
+    expect(result).toEqual([
+      { filename: 'a.ts', scopeId: 'fn1', code: 1001 },
+      { filename: 'a.ts', scopeId: 'fn1', code: 1003 },
+      { filename: 'a.ts', scopeId: 'fn2', code: 1002 },
+      { filename: 'b.ts', scopeId: 'fn1', code: 1001 },
+      { filename: 'c.ts', scopeId: 'fn1', code: 1001 }
+    ]);
+  });
+
+  it('produces deterministic output regardless of input order', () => {
+    const items: BulkSuppressor[] = [
+      { filename: 'z.ts', scopeId: 'a', code: 3 },
+      { filename: 'a.ts', scopeId: 'z', code: 1 },
+      { filename: 'a.ts', scopeId: 'a', code: 2 }
+    ];
+    const reversed = [...items].reverse();
+    expect(deduplicateSuppressors(items)).toEqual(deduplicateSuppressors(reversed));
+  });
+});
+
+describe('Suppression output idempotency', () => {
+  const toolScriptPath = path.resolve(__dirname, '../dist/index.js');
+  const appDir = path.resolve(__dirname, 'fixtures', 'node');
+  const bulkConfigPath = path.resolve(appDir, '.ts-bulk-suppressions.json');
+
+  afterAll(() => {
+    if (existsSync(bulkConfigPath)) rmSync(bulkConfigPath);
+  });
+
+  it('produces identical output on consecutive runs', () => {
+    if (existsSync(bulkConfigPath)) rmSync(bulkConfigPath);
+
+    execSync(`node ${toolScriptPath} --gen-bulk-suppress`, { cwd: appDir });
+    const firstRun = readFileSync(bulkConfigPath, 'utf-8');
+
+    execSync(`node ${toolScriptPath} --gen-bulk-suppress`, { cwd: appDir });
+    const secondRun = readFileSync(bulkConfigPath, 'utf-8');
+
+    expect(firstRun).toBe(secondRun);
   });
 });


### PR DESCRIPTION
## Summary

- Sort `bulkSuppressors` by filename, scopeId, then code after deduplication in `deduplicateSuppressors()`
- Eliminates unnecessary git diffs when regenerating suppressions across runs
- Adds unit tests for dedup correctness, sort order, and determinism, plus an integration test for two-run idempotency

## Test plan

- [x] `pnpm build` compiles successfully
- [x] `pnpm test` — all 37 tests pass (33 existing + 4 new)
- [ ] Manual: run `--gen-bulk-suppress` twice on a project, diff output files — should be identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)